### PR TITLE
fix: localization typos, leap year logic and hardcoded strings

### DIFF
--- a/app/src/main/java/com/nmd/eventCalendar/EventCalendarComposeActivity.kt
+++ b/app/src/main/java/com/nmd/eventCalendar/EventCalendarComposeActivity.kt
@@ -66,8 +66,9 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.isoDayNumber
 import kotlinx.datetime.plus
 import kotlinx.datetime.todayIn
+import kotlinx.datetime.until
 import kotlin.random.Random
-import kotlin.time.Clock
+import kotlinx.datetime.Clock
 
 class EventCalendarComposeActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -136,14 +137,14 @@ fun Screen(
 
     val onDaySelected: (CalendarDay) -> Unit = remember {
         {
-            Log.i("EventCalendarCompose", "Selected day: ${it.date}")
-            Log.i("EventCalendarCompose", "Selected events: ${it.events}")
+            Log.i("EventCalendarCompose", \"Selected day: ${it.date}\")
+            Log.i("EventCalendarCompose", \"Selected events: ${it.events}\")
             selectedDateForSheet = it.date.toString()
         }
     }
 
     val onMonthChange: (YearMonth) -> Unit = remember {
-        { Log.i("EventCalendarCompose", "Selected month: $it") }
+        { Log.i("EventCalendarCompose", \"Selected month: $it\") }
     }
 
     val onWeekStartClick: () -> Unit = remember {
@@ -187,7 +188,7 @@ fun Screen(
                     IconButton(onClick = callback) {
                         Icon(
                             painter = painterResource(R.drawable.icon_arrow_left),
-                            contentDescription = "Back",
+                            contentDescription = stringResource(R.string.content_description_back),
                             tint = iconTint
                         )
                     }
@@ -196,41 +197,42 @@ fun Screen(
                     IconButton(onClick = onShowCurrentWeek) {
                         Icon(
                             painter = painterResource(R.drawable.icon_calendar_week_begin_outline),
-                            contentDescription = "Show current week",
+                            contentDescription = stringResource(R.string.content_description_show_current_week),
                             tint = iconTint
                         )
                     }
                     IconButton(onClick = onWeekStartClick) {
                         Icon(
                             painter = painterResource(R.drawable.icon_calendar_start),
-                            contentDescription = "Change week start",
+                            contentDescription = stringResource(R.string.content_description_change_week_start),
                             tint = iconTint
                         )
                     }
                     IconButton(onClick = onJumpToCurrentMonth) {
                         Icon(
                             painter = painterResource(R.drawable.icon_calendar_today),
-                            contentDescription = "Jump to current month",
+                            contentDescription = stringResource(R.string.content_description_jump_to_current_month),
                             tint = iconTint
                         )
                     }
                     IconButton(onClick = onShuffleEvents) {
                         Icon(
                             painter = painterResource(R.drawable.icon_shuffle),
-                            contentDescription = "Shuffle events",
+                            contentDescription = stringResource(R.string.content_description_shuffle_events),
                             tint = iconTint
                         )
                     }
                     IconButton(onClick = { viewMode = (viewMode + 1) % 4 }) {
                         val icon = when (viewMode) {
-                            0 -> R.drawable.icon_calendar_today
+                            0 -> R.drawable.icon_view_dashboard_outline
                             1 -> R.drawable.icon_calendar_week_begin_outline
                             2 -> R.drawable.icon_calendar_start
-                            else -> R.drawable.icon_calendar_today
+                            3 -> R.drawable.icon_calendar_today_outline
+                            else -> R.drawable.icon_view_dashboard_outline
                         }
                         Icon(
                             painter = painterResource(icon),
-                            contentDescription = "Switch View",
+                            contentDescription = stringResource(R.string.content_description_switch_view),
                             tint = iconTint
                         )
                     }
@@ -246,7 +248,7 @@ fun Screen(
             ) {
                 Icon(
                     painter = painterResource(id = R.drawable.icon_calendar_week_begin_outline),
-                    contentDescription = "Toggle calendar week"
+                    contentDescription = stringResource(R.string.content_description_toggle_calendar_week)
                 )
             }
         },
@@ -286,7 +288,7 @@ fun Screen(
                     selectedDateForSheet = date.toString()
                 },
                 onEventSelected = { event ->
-                    Log.i("EventCalendarCompose", "Clicked on event: ${event.name}")
+                    Log.i("EventCalendarCompose", \"Clicked on event: ${event.name}\")
                     selectedDateForSheet = event.date.toString()
                 }
             )
@@ -365,7 +367,7 @@ private fun CurrentWeekSheetContent(
 
         val today = remember { Clock.System.todayIn(TimeZone.currentSystemDefault()) }
         val monthName = stringResource(today.month.toStringRes())
-        val monthTitle = "$monthName ${today.year}"
+        val monthTitle = \"$monthName ${today.year}\"
 
         Text(
             text = monthTitle,
@@ -399,7 +401,7 @@ private fun CurrentWeekSheetContent(
             calendarController = weekController,
             calendarEventsStore = calendarEventsStore,
             onDaySelected = { day ->
-                Log.i("EventCalendarCompose", "Selected week day: ${day.date}")
+                Log.i("EventCalendarCompose", \"Selected week day: ${day.date}\")
             },
             onMonthChange = {}
         )
@@ -416,11 +418,13 @@ private fun shuffleEventsForCurrentYear(
     val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
     val year = today.year
     val start = LocalDate(year, 1, 1)
+    val end = LocalDate(year + 1, 1, 1)
+    val daysInYear = start.until(end, kotlinx.datetime.DateTimeUnit.DAY)
     val rnd = Random(seed)
 
     return List(eventCount) {
         val (name, shape) = templates[rnd.nextInt(templates.size)]
-        val date = start.plus(rnd.nextInt(365), kotlinx.datetime.DateTimeUnit.DAY)
+        val date = start.plus(rnd.nextInt(daysInYear), kotlinx.datetime.DateTimeUnit.DAY)
 
         val hasTime = rnd.nextBoolean()
         val timeRange = if (hasTime) {
@@ -440,90 +444,90 @@ private fun shuffleEventsForCurrentYear(
 }
 
 private val eventTemplates: List<Pair<String, Color>> = listOf(
-    "Meeting" to Color(0xFFE07912),
-    "Vacation" to Color(0xFF4BADEB),
-    "Birthday Party" to Color(0xFFFF6F00),
-    "Concert" to Color(0xFFD500F9),
-    "Job Interview" to Color(0xFF7CB342),
-    "Doctor's Appointment" to Color(0xFF29B6F6),
-    "Gym Session" to Color(0xFFEF5350),
-    "Networking Event" to Color(0xFFAB47BC),
-    "Movie Night" to Color(0xFFFFEE58),
-    "Dinner Date" to Color(0xFF26A69A),
-    "Business Trip" to Color(0xFF8D6E63),
-    "Charity Event" to Color(0xFFFF9800),
-    "Book Club Meeting" to Color(0xFFB71C1C),
-    "Coffee with Friends" to Color(0xFF9CCC65),
-    "Music Festival" to Color(0xFF7E57C2),
-    "Volunteering" to Color(0xFF78909C),
-    "Sports Game" to Color(0xFFF44336),
-    "Art Exhibition" to Color(0xFF9C27B0),
-    "Language Exchange" to Color(0xFF4CAF50),
-    "Hiking Trip" to Color(0xFFCDDC39),
-    "Yoga Class" to Color(0xFF26C6DA),
-    "Baking Workshop" to Color(0xFFFFAB00),
-    "Science Fair" to Color(0xFF6A1B9A),
-    "Board Game Night" to Color(0xFF607D8B),
-    "Fashion Show" to Color(0xFFF57C00),
-    "Political Rally" to Color(0xFF009688),
-    "Writing Workshop" to Color(0xFFFF4081),
-    "Tech Conference" to Color(0xFF1565C0),
-    "Wine Tasting" to Color(0xFF8BC34A),
-    "Cooking Class" to Color(0xFFF4511E),
-    "Open Mic Night" to Color(0xFF673AB7),
-    "Karaoke Night" to Color(0xFFFF5252),
-    "Outdoor Concert" to Color(0xFF64DD17),
-    "Flea Market" to Color(0xFF9E9E9E),
-    "Art Museum Tour" to Color(0xFFFF1744),
-    "Escape Room" to Color(0xFF00BCD4),
-    "Photography Workshop" to Color(0xFFFFD600),
-    "Ballet Performance" to Color(0xFF9FA8DA),
-    "Fashion Design Course" to Color(0xFF4CAF4F),
-    "Community Service" to Color(0xFFC2185B),
-    "Trivia Night" to Color(0xFF2196F3),
-    "Chess Tournament" to Color(0xFFAFB42B),
-    "Stand-up Comedy Show" to Color(0xFF795548),
-    "Book Signing" to Color(0xFFE91E63),
-    "Potluck Party" to Color(0xFF689F38),
-    "Art Auction" to Color(0xFFBA68C8),
-    "Game Night" to Color(0xFF00897B),
-    "Beer Tasting" to Color(0xFFFFD54F),
-    "Stand-up Paddleboarding" to Color(0xFF0277BD),
-    "Charity Run" to Color(0xFFF57F17),
-    "Poetry Slam" to Color(0xFFF44336),
-    "Board Game Cafe" to Color(0xFF8BC34A),
-    "Movie Marathon" to Color(0xFFB71C1C),
-    "Bike Tour" to Color(0xFF4DB6AC),
-    "Wine and Paint Night" to Color(0xFF9C27B0),
-    "Plant Swap" to Color(0xFF388E3C),
-    "Beach Clean-up" to Color(0xFF009688),
-    "Indoor Skydiving" to Color(0xFFFF6F00),
-    "Ice Skating" to Color(0xFF0277BD),
-    "Farmers Market" to Color(0xFFCDDC39),
-    "Game of Thrones Marathon" to Color(0xFF6D4C41),
-    "Soap Making Workshop" to Color(0xFF26A69A),
-    "Beer and Cheese Pairing" to Color(0xFFFFAB00),
-    "Group Painting Session" to Color(0xFFFFA000),
-    "Food Truck Festival" to Color(0xFFF06292),
-    "Ghost Tour" to Color(0xFF7E57C2),
-    "Sushi Making Class" to Color(0xFF0091EA),
-    "Aquarium Visit" to Color(0xFFB2FF59),
-    "Murder Mystery Dinner" to Color(0xFFD500F9),
-    "Vintage Clothing Market" to Color(0xFFF57C00),
-    "Rock Climbing" to Color(0xFF6A1B9A),
-    "DIY Woodworking Class" to Color(0xFF795548),
-    "Meditation Retreat" to Color(0xFF0097A7),
-    "Group Bike Ride" to Color(0xFFD32F2F),
-    "Cooking Competition" to Color(0xFFFF5252),
-    "Haunted House Visit" to Color(0xFFBA68C8),
-    "Beach Volleyball" to Color(0xFFFFA000),
-    "Gardening Workshop" to Color(0xFF4DB6AC),
-    "Laser Tag" to Color(0xFF673AB7),
-    "Bird Watching Tour" to Color(0xFFFF4081),
-    "Movie in the Park" to Color(0xFF43A047),
-    "Cider Tasting" to Color(0xFFEF5350),
-    "Escape Game" to Color(0xFF29B6F6),
-    "Cheese Making Class" to Color(0xFFFFC107),
+    \"Meeting\" to Color(0xFFE07912),
+    \"Vacation\" to Color(0xFF4BADEB),
+    \"Birthday Party\" to Color(0xFFFF6F00),
+    \"Concert\" to Color(0xFFD500F9),
+    \"Job Interview\" to Color(0xFF7CB342),
+    \"Doctor's Appointment\" to Color(0xFF29B6F6),
+    \"Gym Session\" to Color(0xFFEF5350),
+    \"Networking Event\" to Color(0xFFAB47BC),
+    \"Movie Night\" to Color(0xFFFFEE58),
+    \"Dinner Date\" to Color(0xFF26A69A),
+    \"Business Trip\" to Color(0xFF8D6E63),
+    \"Charity Event\" to Color(0xFFFF9800),
+    \"Book Club Meeting\" to Color(0xFFB71C1C),
+    \"Coffee with Friends\" to Color(0xFF9CCC65),
+    \"Music Festival\" to Color(0xFF7E57C2),
+    \"Volunteering\" to Color(0xFF78909C),
+    \"Sports Game\" to Color(0xFFF44336),
+    \"Art Exhibition\" to Color(0xFF9C27B0),
+    \"Language Exchange\" to Color(0xFF4CAF50),
+    \"Hiking Trip\" to Color(0xFFCDDC39),
+    \"Yoga Class\" to Color(0xFF26C6DA),
+    \"Baking Workshop\" to Color(0xFFFFAB00),
+    \"Science Fair\" to Color(0xFF6A1B9A),
+    \"Board Game Night\" to Color(0xFF607D8B),
+    \"Fashion Show\" to Color(0xFFF57C00),
+    \"Political Rally\" to Color(0xFF009688),
+    \"Writing Workshop\" to Color(0xFFFF4081),
+    \"Tech Conference\" to Color(0xFF1565C0),
+    \"Wine Tasting\" to Color(0xFF8BC34A),
+    \"Cooking Class\" to Color(0xFFF4511E),
+    \"Open Mic Night\" to Color(0xFF673AB7),
+    \"Karaoke Night\" to Color(0xFFFF5252),
+    \"Outdoor Concert\" to Color(0xFF64DD17),
+    \"Flea Market\" to Color(0xFF9E9E9E),
+    \"Art Museum Tour\" to Color(0xFFFF1744),
+    \"Escape Room\" to Color(0xFF00BCD4),
+    \"Photography Workshop\" to Color(0xFFFFD600),
+    \"Ballet Performance\" to Color(0xFF9FA8DA),
+    \"Fashion Design Course\" to Color(0xFF4CAF4F),
+    \"Community Service\" to Color(0xFFC2185B),
+    \"Trivia Night\" to Color(0xFF2196F3),
+    \"Chess Tournament\" to Color(0xFFAFB42B),
+    \"Stand-up Comedy Show\" to Color(0xFF795548),
+    \"Book Signing\" to Color(0xFFE91E63),
+    \"Potluck Party\" to Color(0xFF689F38),
+    \"Art Auction\" to Color(0xFFBA68C8),
+    \"Game Night\" to Color(0xFF00897B),
+    \"Beer Tasting\" to Color(0xFFFFD54F),
+    \"Stand-up Paddleboarding\" to Color(0xFF0277BD),
+    \"Charity Run\" to Color(0xFFF57F17),
+    \"Poetry Slam\" to Color(0xFFF44336),
+    \"Board Game Cafe\" to Color(0xFF8BC34A),
+    \"Movie Marathon\" to Color(0xFFB71C1C),
+    \"Bike Tour\" to Color(0xFF4DB6AC),
+    \"Wine and Paint Night\" to Color(0xFF9C27B0),
+    \"Plant Swap\" to Color(0xFF388E3C),
+    \"Beach Clean-up\" to Color(0xFF009688),
+    \"Indoor Skydiving\" to Color(0xFFFF6F00),
+    \"Ice Skating\" to Color(0xFF0277BD),
+    \"Farmers Market\" to Color(0xFFCDDC39),
+    \"Game of Thrones Marathon\" to Color(0xFF6D4C41),
+    \"Soap Making Workshop\" to Color(0xFF26A69A),
+    \"Beer and Cheese Pairing\" to Color(0xFFFFAB00),
+    \"Group Painting Session\" to Color(0xFFFFA000),
+    \"Food Truck Festival\" to Color(0xFFF06292),
+    \"Ghost Tour\" to Color(0xFF7E57C2),
+    \"Sushi Making Class\" to Color(0xFF0091EA),
+    \"Aquarium Visit\" to Color(0xFFB2FF59),
+    \"Murder Mystery Dinner\" to Color(0xFFD500F9),
+    \"Vintage Clothing Market\" to Color(0xFFF57C00),
+    \"Rock Climbing\" to Color(0xFF6A1B9A),
+    \"DIY Woodworking Class\" to Color(0xFF795548),
+    \"Meditation Retreat\" to Color(0xFF0097A7),
+    \"Group Bike Ride\" to Color(0xFFD32F2F),
+    \"Cooking Competition\" to Color(0xFFFF5252),
+    \"Haunted House Visit\" to Color(0xFFBA68C8),
+    \"Beach Volleyball\" to Color(0xFFFFA000),
+    \"Gardening Workshop\" to Color(0xFF4DB6AC),
+    \"Laser Tag\" to Color(0xFF673AB7),
+    \"Bird Watching Tour\" to Color(0xFFFF4081),
+    \"Movie in the Park\" to Color(0xFF43A047),
+    \"Cider Tasting\" to Color(0xFFEF5350),
+    \"Escape Game\" to Color(0xFF29B6F6),
+    \"Cheese Making Class\" to Color(0xFFFFC107),
 )
 
 @Preview(showBackground = true)


### PR DESCRIPTION
This PR addresses Issue #18 by fixing localization typos, improving leap year logic in event generation, and removing hardcoded strings in the Compose module.

### Changes:
- **Localization**: Fixed "where" typo in `event_calendar_no_events` (English).
- **Strings**: Added missing `contentDescription` resources for better accessibility.
- **Compose Activity**:
    - Replaced hardcoded strings with `stringResource()`.
    - Improved `shuffleEventsForCurrentYear` to correctly handle leap years using `kotlinx-datetime` distance calculation.
    - Updated ViewMode icons to be unique (Month now uses a dashboard/grid icon, Day uses an outline icon).