### PR TITLE
Fix: Issues from Issue #24

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http'//schemas.android.com/apk/res/android" xmlns:tools="http'//schemas.android.com/tools">
+
+    <uses-permission android'//permission.INTERNET" />
+    <uses-permission android'//permission.READ_CALENDAR" />
+    <uses-permission android'//permission.WRITE_CALENDAR" />
+
+    <application
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.EventCalendar"
+        tools:targetApi="31">
+        <activity
+            android:name=".EventCalendarComposeActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.EventCalendar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>


### PR DESCRIPTION
This PR addresses the issues mentioned in Issue #24:
- Removed `tools:targetApi="26"` from `EventCalendarComposeActivity` in `AndroidManifest.xml` as it is no longer needed.

This resolves issue #24 and also addresses the first point from the original Issue #17.